### PR TITLE
Test ARM release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,11 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
 checksum:
   name_template: '{{ .ProjectName }}_{{.Env.RELEASE_VERSION}}_checksums.txt'
 changelog:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: healthcheck
+version: git
+summary: The health-check command-line tool concurrently checks all target groups' health status.
+description: |
+  The health-check command-line tool concurrently checks all target groups' health status (for target groups that are attached to a load balancer).
+  The program returns 0 when you have at least one healthy target for each service.
+architectures:
+  - build-on: arm64
+assumes: [snapd2.45]
+base: core18
+ 
+grade: stable
+confinement: strict
+ 
+apps:
+  tfswihealthchecktch:
+    command: bin/healthcheck
+    plugs:
+      - home
+      - network
+      - network-bind
+      
+parts:
+  healthcheck:
+    source: .
+    plugin: go
+    go-importpath: github.com/warrensbox/health-check
+    build-packages:
+      - gcc-multilib
+    go-buildtags:
+      - healthcheck
+    override-build: 
+      go build  -o ../install/bin/healthcheck

--- a/www/docs/Quick-start.md
+++ b/www/docs/Quick-start.md
@@ -31,7 +31,7 @@ docker run --rm \
   -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
   -e AWS_REGION=${AWS_REGION} \
   -e AWS_DEFAULT_REGION=${AWS_REGION} \
-  health-check --ecs-cluster esp-devops --attempts 50 --delay
+  health-check --ecs-cluster esp-devops --attempts 50 --delay 2
 
   ## pass -b to disable progress bar on jenkins
 ```

--- a/www/docs/Quick-start.md
+++ b/www/docs/Quick-start.md
@@ -31,5 +31,7 @@ docker run --rm \
   -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} \
   -e AWS_REGION=${AWS_REGION} \
   -e AWS_DEFAULT_REGION=${AWS_REGION} \
-  health-check --ecs-cluster esp-devops --attempts 50 --delay 2 
+  health-check --ecs-cluster esp-devops --attempts 50 --delay
+
+  ## pass -b to disable progress bar on jenkins
 ```


### PR DESCRIPTION
Testing:
    goarch:
      - amd64
      - arm
      - arm64

    # GOARM to build for when GOARCH is arm.
    # For more info refer to: https://golang.org/doc/install/source#environment
    # Default is only 6.
    goarm:
      - 6
      - 7